### PR TITLE
Add support for dash and dot notation

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -28,6 +28,10 @@ const SemverCreateTestCases = [
     input: ['v1.2.3', 'patch', 'rc.abcdef0'],
     expected: { string: '1.2.4-rc.abcdef0', major: 1, minor: 2, patch: 4, suffix: 'rc.abcdef0' },
   },
+  {
+    input: ['v1.24.0-rc.0', 'patch'],
+    expected: { string: '1.24.1', major: 1, minor: 24, patch: 1 },
+  },
 ];
 
 describe('Utility Functions', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,9 +6,10 @@ import type { Semver } from './types.js';
  * V1.2.3
  * 1.2.3
  * 1.2.3-suffix
+ * 1.2.3-suffix.0
  */
 export const parseSemver = (semver: string) => {
-  if (!semver.match(/^(v|V)?\d+\.\d+\.\d+(-\w+)?$/)) {
+  if (!semver.match(/^(v|V)?\d+\.\d+\.\d+(-\w+(?:\.\w+)*)?$/)) {
     throw new Error(`Invalid semver: ${semver}`);
   }
 


### PR DESCRIPTION
We have a case where our tags are currently denoted with a release candidate (rc) and a version of that rc.

I've added support for the dot notation of the rc that we have, and also included a test.